### PR TITLE
fix: revert broken recommendation caching causing latency spike

### DIFF
--- a/src/recommendation/recommendation_server.py
+++ b/src/recommendation/recommendation_server.py
@@ -37,10 +37,6 @@ from metrics import (
 )
 
 
-cached_ids = []
-cached_ids_to_retrieve_recommendations_for = []
-MAX_CACHED_IDS = 2000000
-
 first_run = True
 
 class RecommendationService(demo_pb2_grpc.RecommendationServiceServicer):
@@ -67,31 +63,6 @@ class RecommendationService(demo_pb2_grpc.RecommendationServiceServicer):
         return health_pb2.HealthCheckResponse(
             status=health_pb2.HealthCheckResponse.UNIMPLEMENTED)
 
-def get_recommendations_ids(request_product_ids):
-    global cached_ids
-
-    with tracer.start_as_current_span("get_recommendations_ids") as span:
-        can_retrieve_from_cache = True
-        for p_id in request_product_ids:
-            if p_id not in cached_ids_to_retrieve_recommendations_for:
-                can_retrieve_from_cache = False
-
-        if not can_retrieve_from_cache:
-            logger.info("get_recommendations_ids: cache miss")
-            span.set_attribute("app.cache_hit", False)
-            cat_response = product_catalog_stub.ListProducts(demo_pb2.Empty())
-            ids_to_add = []
-            for x in cat_response.products:
-                ids_to_add.extend(cached_ids)
-                ids_to_add.append(x.id)
-                if len(ids_to_add) + len(cached_ids) < MAX_CACHED_IDS:
-                    cached_ids= cached_ids + ids_to_add
-            return cached_ids
-        else:
-            logger.info("get_recommendations_ids: cache hit")
-            span.set_attribute("app.cache_hit", True)
-            return cached_ids
-
 def get_product_list(request_product_ids):
     global first_run
     with tracer.start_as_current_span("get_product_list") as span:
@@ -101,7 +72,8 @@ def get_product_list(request_product_ids):
         request_product_ids_str = ''.join(request_product_ids)
         request_product_ids = request_product_ids_str.split(',')
 
-        product_ids = get_recommendations_ids(request_product_ids)
+        cat_response = product_catalog_stub.ListProducts(demo_pb2.Empty())
+        product_ids = [x.id for x in cat_response.products]
 
         span.set_attribute("app.products.count", len(product_ids))
 

--- a/src/recommendation/recommendation_server.py
+++ b/src/recommendation/recommendation_server.py
@@ -36,6 +36,11 @@ from metrics import (
     init_metrics
 )
 
+
+cached_ids = []
+cached_ids_to_retrieve_recommendations_for = []
+MAX_CACHED_IDS = 2000000
+
 first_run = True
 
 class RecommendationService(demo_pb2_grpc.RecommendationServiceServicer):
@@ -62,6 +67,30 @@ class RecommendationService(demo_pb2_grpc.RecommendationServiceServicer):
         return health_pb2.HealthCheckResponse(
             status=health_pb2.HealthCheckResponse.UNIMPLEMENTED)
 
+def get_recommendations_ids(request_product_ids):
+    global cached_ids
+
+    with tracer.start_as_current_span("get_recommendations_ids") as span:
+        can_retrieve_from_cache = True
+        for p_id in request_product_ids:
+            if p_id not in cached_ids_to_retrieve_recommendations_for:
+                can_retrieve_from_cache = False
+
+        if not can_retrieve_from_cache:
+            logger.info("get_recommendations_ids: cache miss")
+            span.set_attribute("app.cache_hit", False)
+            cat_response = product_catalog_stub.ListProducts(demo_pb2.Empty())
+            ids_to_add = []
+            for x in cat_response.products:
+                ids_to_add.extend(cached_ids)
+                ids_to_add.append(x.id)
+                if len(ids_to_add) + len(cached_ids) < MAX_CACHED_IDS:
+                    cached_ids= cached_ids + ids_to_add
+            return cached_ids
+        else:
+            logger.info("get_recommendations_ids: cache hit")
+            span.set_attribute("app.cache_hit", True)
+            return cached_ids
 
 def get_product_list(request_product_ids):
     global first_run
@@ -72,8 +101,7 @@ def get_product_list(request_product_ids):
         request_product_ids_str = ''.join(request_product_ids)
         request_product_ids = request_product_ids_str.split(',')
 
-        cat_response = product_catalog_stub.ListProducts(demo_pb2.Empty())
-        product_ids = [x.id for x in cat_response.products]
+        product_ids = get_recommendations_ids(request_product_ids)
 
         span.set_attribute("app.products.count", len(product_ids))
 


### PR DESCRIPTION
## Problem

An active alert was triggered: **Avg. latency for `GET /api/recommendations` on `frontend-proxy` is 355ms** (threshold: 200ms).

Root cause analysis traced the issue through the service topology:

```
load-generator → frontend-proxy → frontend → recommendation → product-catalog
```

The [recommendation](/app/apm/services/recommendation) service's `/oteldemo.RecommendationService/ListRecommendations` transaction experienced a **step change in latency at ~2026-03-11T09:03:00Z**, jumping from ~5ms to **400ms+**. This was identified as the root cause propagating latency up through `frontend` and `frontend-proxy`.

## Root Cause

Commit `c1d42f47fa01f6b0696660c13fd8f1e4b762be71` introduced a caching mechanism in `get_recommendations_ids()` with a critical bug:

```python
for x in cat_response.products:
    ids_to_add.extend(cached_ids)   # ← BUG: exponential growth!
    ids_to_add.append(x.id)
    if len(ids_to_add) + len(cached_ids) < MAX_CACHED_IDS:
        cached_ids = cached_ids + ids_to_add
```

On every cache miss, `ids_to_add.extend(cached_ids)` is called **once per product** inside the loop, causing **O(n²) growth** of `ids_to_add`. With `MAX_CACHED_IDS = 2,000,000`, `cached_ids` rapidly inflates to millions of entries, causing extreme memory pressure and CPU time on every subsequent request.

## Fix

Reverts the broken caching logic and restores the original direct call to `product_catalog_stub.ListProducts()` in `get_product_list()`.

## Impact

- Latency on `recommendation` service: ~400ms → ~5ms
- Latency on `frontend-proxy` `GET /api/recommendations`: ~355ms → expected <50ms
