### PR TITLE
fix: revert buggy caching logic in recommendation service causing latency spike

### DIFF
--- a/src/recommendation/recommendation_server.py
+++ b/src/recommendation/recommendation_server.py
@@ -37,9 +37,6 @@ from metrics import (
 )
 
 first_run = True
-cached_ids = []
-cached_ids_to_retrieve_recommendations_for = []
-MAX_CACHED_IDS = 2000000
 
 class RecommendationService(demo_pb2_grpc.RecommendationServiceServicer):
     def ListRecommendations(self, request, context):
@@ -65,31 +62,6 @@ class RecommendationService(demo_pb2_grpc.RecommendationServiceServicer):
         return health_pb2.HealthCheckResponse(
             status=health_pb2.HealthCheckResponse.UNIMPLEMENTED)
 
-def get_recommendations_ids(request_product_ids):
-    global cached_ids
-
-    with tracer.start_as_current_span("get_recommendations_ids") as span:
-        can_retrieve_from_cache = True
-        for p_id in request_product_ids:
-            if p_id not in cached_ids_to_retrieve_recommendations_for:
-                can_retrieve_from_cache = False
-
-        if not can_retrieve_from_cache:
-            logger.info("get_recommendations_ids: cache miss")
-            span.set_attribute("app.cache_hit", False)
-            cat_response = product_catalog_stub.ListProducts(demo_pb2.Empty())
-            ids_to_add = []
-            for x in cat_response.products:
-                ids_to_add.extend(cached_ids)
-                ids_to_add.append(x.id)
-                if len(ids_to_add) + len(cached_ids) < MAX_CACHED_IDS:
-                    cached_ids= cached_ids + ids_to_add
-            return cached_ids
-        else:
-            logger.info("get_recommendations_ids: cache hit")
-            span.set_attribute("app.cache_hit", True)
-            return cached_ids
-
 def get_product_list(request_product_ids):
     global first_run
     with tracer.start_as_current_span("get_product_list") as span:
@@ -99,7 +71,8 @@ def get_product_list(request_product_ids):
         request_product_ids_str = ''.join(request_product_ids)
         request_product_ids = request_product_ids_str.split(',')
 
-        product_ids = get_recommendations_ids(request_product_ids)
+        cat_response = product_catalog_stub.ListProducts(demo_pb2.Empty())
+        product_ids = [x.id for x in cat_response.products]
 
         span.set_attribute("app.products.count", len(product_ids))
 


### PR DESCRIPTION
## Problem

An active alert was triggered: **Avg. latency for `GET /api/recommendations` on `frontend-proxy` is 393ms** (threshold: 200ms).

### Root Cause Analysis

Automated investigation traced the latency spike through the call chain:

```
load-generator → frontend-proxy → frontend → recommendation → product-catalog
```

The [recommendation](/app/apm/services/recommendation) service showed a **dramatic latency spike** starting around `2026-03-11T11:30:00Z`, jumping from ~5ms to **400ms+** per `ListRecommendations` call.

Correlation analysis identified commit `a5343cd689809fc45e53b097087ef0fd36c4d45a` as the root cause.

### The Bug

The `get_recommendations_ids` function introduced in the problematic commit contains a critical bug in the cache-miss path:

```python
for x in cat_response.products:
    ids_to_add.extend(cached_ids)  # ← BUG: appends entire cached_ids on every iteration
    ids_to_add.append(x.id)
    if len(ids_to_add) + len(cached_ids) < MAX_CACHED_IDS:
        cached_ids = cached_ids + ids_to_add  # ← BUG: exponential growth
```

On every cache miss, `ids_to_add.extend(cached_ids)` is called **once per product** in the catalog, causing the list to grow exponentially. With `MAX_CACHED_IDS = 2,000,000`, this results in massive memory allocation and CPU time on every request, causing 400ms+ latency.

## Fix

Reverts to the original, correct implementation that directly calls `product_catalog_stub.ListProducts()` without the broken caching layer.

## Impact

- **Affected service**: [recommendation](/app/apm/services/recommendation)
- **Downstream impact**: [frontend-proxy](/app/apm/services/frontend-proxy) → [frontend](/app/apm/services/frontend) → [recommendation](/app/apm/services/recommendation)
- **Alert**: Latency threshold exceeded (393ms avg vs 200ms threshold)