### PR TITLE
fix: revert broken recommendation cache causing latency regression

### DIFF
--- a/src/recommendation/recommendation_server.py
+++ b/src/recommendation/recommendation_server.py
@@ -37,9 +37,6 @@ from metrics import (
 )
 
 first_run = True
-cached_ids = []
-cached_ids_to_retrieve_recommendations_for = []
-MAX_CACHED_IDS = 2000000
 
 class RecommendationService(demo_pb2_grpc.RecommendationServiceServicer):
     def ListRecommendations(self, request, context):
@@ -65,31 +62,6 @@ class RecommendationService(demo_pb2_grpc.RecommendationServiceServicer):
         return health_pb2.HealthCheckResponse(
             status=health_pb2.HealthCheckResponse.UNIMPLEMENTED)
 
-def get_recommendations_ids(request_product_ids):
-    global cached_ids
-
-    with tracer.start_as_current_span("get_recommendations_ids") as span:
-        can_retrieve_from_cache = True
-        for p_id in request_product_ids:
-            if p_id not in cached_ids_to_retrieve_recommendations_for:
-                can_retrieve_from_cache = False
-
-        if not can_retrieve_from_cache:
-            logger.info("get_recommendations_ids: cache miss")
-            span.set_attribute("app.cache_hit", False)
-            cat_response = product_catalog_stub.ListProducts(demo_pb2.Empty())
-            ids_to_add = []
-            for x in cat_response.products:
-                ids_to_add.extend(cached_ids)
-                ids_to_add.append(x.id)
-                if len(ids_to_add) + len(cached_ids) < MAX_CACHED_IDS:
-                    cached_ids= cached_ids + ids_to_add
-            return cached_ids
-        else:
-            logger.info("get_recommendations_ids: cache hit")
-            span.set_attribute("app.cache_hit", True)
-            return cached_ids
-
 def get_product_list(request_product_ids):
     global first_run
     with tracer.start_as_current_span("get_product_list") as span:
@@ -99,7 +71,8 @@ def get_product_list(request_product_ids):
         request_product_ids_str = ''.join(request_product_ids)
         request_product_ids = request_product_ids_str.split(',')
 
-        product_ids = get_recommendations_ids(request_product_ids)
+        cat_response = product_catalog_stub.ListProducts(demo_pb2.Empty())
+        product_ids = [x.id for x in cat_response.products]
 
         span.set_attribute("app.products.count", len(product_ids))
 


### PR DESCRIPTION
## Problem

An active latency alert was triggered for `frontend-proxy` → `GET /api/recommendations` with avg latency of **318 ms** (threshold: 200 ms).

Root cause analysis traced the issue to commit `a5343cd689809fc45e53b097087ef0fd36c4d45a` in the `recommendation` service, which introduced a faulty caching mechanism in `get_recommendations_ids()`.

## Root Cause

The introduced `get_recommendations_ids()` function contains two critical bugs:

1. **Unbounded memory growth**: Inside the `for x in cat_response.products` loop, `ids_to_add.extend(cached_ids)` is called on every iteration, causing `ids_to_add` to grow exponentially with each product entry.
2. **Incorrect cache population**: The function appends the entire `cached_ids` list into `ids_to_add` for every product, then appends that back into `cached_ids`, causing the list to balloon to millions of entries (up to `MAX_CACHED_IDS = 2,000,000`).
3. **Cache never warms correctly**: `cached_ids_to_retrieve_recommendations_for` is never populated, so the cache always misses and the expensive (and now broken) path is always taken.

This results in massive list operations on every recommendation request, causing significant CPU overhead and latency.

## Fix

Reverts `get_product_list()` to directly call `product_catalog_stub.ListProducts()` and removes the broken `get_recommendations_ids()` function and associated globals (`cached_ids`, `cached_ids_to_retrieve_recommendations_for`, `MAX_CACHED_IDS`).

## Evidence

- Latency correlation analysis identified `git.sha: a5343cd689809fc45e53b097087ef0fd36c4d45a` as strongly correlated with the latency increase
- Pod `recommendation-7694b988b6-nb745` started at `2026-03-11T13:20:26Z`, aligning with the alert start time of `2026-03-11T13:25:46Z`
- `recommendation` service avg latency: **109 ms** for `/oteldemo.RecommendationService/ListRecommendations`