### PR TITLE
fix: revert buggy recommendation cache causing memory bloat and latency spike

### DIFF
--- a/src/recommendation/recommendation_server.py
+++ b/src/recommendation/recommendation_server.py
@@ -37,9 +37,6 @@ from metrics import (
 )
 
 first_run = True
-cached_ids = []
-cached_ids_to_retrieve_recommendations_for = []
-MAX_CACHED_IDS = 2000000
 
 class RecommendationService(demo_pb2_grpc.RecommendationServiceServicer):
     def ListRecommendations(self, request, context):
@@ -65,31 +62,6 @@ class RecommendationService(demo_pb2_grpc.RecommendationServiceServicer):
         return health_pb2.HealthCheckResponse(
             status=health_pb2.HealthCheckResponse.UNIMPLEMENTED)
 
-def get_recommendations_ids(request_product_ids):
-    global cached_ids
-
-    with tracer.start_as_current_span("get_recommendations_ids") as span:
-        can_retrieve_from_cache = True
-        for p_id in request_product_ids:
-            if p_id not in cached_ids_to_retrieve_recommendations_for:
-                can_retrieve_from_cache = False
-
-        if not can_retrieve_from_cache:
-            logger.info("get_recommendations_ids: cache miss")
-            span.set_attribute("app.cache_hit", False)
-            cat_response = product_catalog_stub.ListProducts(demo_pb2.Empty())
-            ids_to_add = []
-            for x in cat_response.products:
-                ids_to_add.extend(cached_ids)
-                ids_to_add.append(x.id)
-                if len(ids_to_add) + len(cached_ids) < MAX_CACHED_IDS:
-                    cached_ids= cached_ids + ids_to_add
-            return cached_ids
-        else:
-            logger.info("get_recommendations_ids: cache hit")
-            span.set_attribute("app.cache_hit", True)
-            return cached_ids
-
 def get_product_list(request_product_ids):
     global first_run
     with tracer.start_as_current_span("get_product_list") as span:
@@ -99,7 +71,8 @@ def get_product_list(request_product_ids):
         request_product_ids_str = ''.join(request_product_ids)
         request_product_ids = request_product_ids_str.split(',')
 
-        product_ids = get_recommendations_ids(request_product_ids)
+        cat_response = product_catalog_stub.ListProducts(demo_pb2.Empty())
+        product_ids = [x.id for x in cat_response.products]
 
         span.set_attribute("app.products.count", len(product_ids))
 


### PR DESCRIPTION
## Problem

An active latency alert fired for `frontend-proxy` on transaction `GET /api/recommendations`:
- **Observed latency**: 616 ms avg (last 5 min)
- **Threshold**: 200 ms

## Root Cause

Commit `375a36eb40eb812fa6b1110585cd863e3daf8535` introduced a `get_recommendations_ids()` caching function in `src/recommendation/recommendation_server.py` that contains a critical bug:

```python
for x in cat_response.products:
    ids_to_add.extend(cached_ids)  # BUG: appends entire cached_ids for EACH product
    ids_to_add.append(x.id)
    if len(ids_to_add) + len(cached_ids) < MAX_CACHED_IDS:
        cached_ids = cached_ids + ids_to_add
```

On every cache miss, `ids_to_add` is extended with the **entire `cached_ids` list** for each product in the catalog. This causes **O(n²) memory growth**, rapidly bloating `cached_ids` up to `MAX_CACHED_IDS` (2,000,000 entries). The resulting memory pressure and list operations cause severe latency degradation on the `recommendation` service, which propagates up through `frontend` → `frontend-proxy`.

## Fix

Reverts `recommendation_server.py` to the original direct product catalog lookup, removing the faulty caching logic entirely.

## Impact
- Affected service: [recommendation](/app/apm/services/recommendation) → [frontend](/app/apm/services/frontend) → [frontend-proxy](/app/apm/services/frontend-proxy)
- Alert: Latency threshold rule on `GET /api/recommendations` (616 ms vs 200 ms threshold)
- Correlated via `git.sha` attribute in latency distribution analysis