### PR TITLE
fix: revert buggy recommendation cache causing latency spike (GET /api/recommendations)

### DIFF
--- a/src/recommendation/recommendation_server.py
+++ b/src/recommendation/recommendation_server.py
@@ -37,10 +37,6 @@ from metrics import (
 )
 
 
-cached_ids = []
-cached_ids_to_retrieve_recommendations_for = []
-MAX_CACHED_IDS = 2000000
-
 first_run = True
 
 class RecommendationService(demo_pb2_grpc.RecommendationServiceServicer):
@@ -67,31 +63,6 @@ class RecommendationService(demo_pb2_grpc.RecommendationServiceServicer):
         return health_pb2.HealthCheckResponse(
             status=health_pb2.HealthCheckResponse.UNIMPLEMENTED)
 
-def get_recommendations_ids(request_product_ids):
-    global cached_ids
-
-    with tracer.start_as_current_span("get_recommendations_ids") as span:
-        can_retrieve_from_cache = True
-        for p_id in request_product_ids:
-            if p_id not in cached_ids_to_retrieve_recommendations_for:
-                can_retrieve_from_cache = False
-
-        if not can_retrieve_from_cache:
-            logger.info("get_recommendations_ids: cache miss")
-            span.set_attribute("app.cache_hit", False)
-            cat_response = product_catalog_stub.ListProducts(demo_pb2.Empty())
-            ids_to_add = []
-            for x in cat_response.products:
-                ids_to_add.extend(cached_ids)
-                ids_to_add.append(x.id)
-                if len(ids_to_add) + len(cached_ids) < MAX_CACHED_IDS:
-                    cached_ids= cached_ids + ids_to_add
-            return cached_ids
-        else:
-            logger.info("get_recommendations_ids: cache hit")
-            span.set_attribute("app.cache_hit", True)
-            return cached_ids
-
 def get_product_list(request_product_ids):
     global first_run
     with tracer.start_as_current_span("get_product_list") as span:
@@ -101,7 +72,8 @@ def get_product_list(request_product_ids):
         request_product_ids_str = ''.join(request_product_ids)
         request_product_ids = request_product_ids_str.split(',')
 
-        product_ids = get_recommendations_ids(request_product_ids)
+        cat_response = product_catalog_stub.ListProducts(demo_pb2.Empty())
+        product_ids = [x.id for x in cat_response.products]
 
         span.set_attribute("app.products.count", len(product_ids))
 


### PR DESCRIPTION
## Problem

A latency alert fired for `GET /api/recommendations` on the `frontend-proxy` service. Avg latency spiked to **754 ms** (threshold: 200 ms) starting at **2026-03-13T10:40 UTC**.

## Root Cause Analysis

Tracing the call chain:
```
load-generator → frontend-proxy → frontend → recommendation → product-catalog
```

Change point analysis identified a **latency spike at 10:40 UTC** across:
- `product-catalog`: 30,420 ms avg (normally ~4,500 ms)
- `recommendation`: 568,495 ms avg (normally ~4,000 ms)
- `frontend`: 1,435,728 ms avg
- `frontend-proxy`: 1,149,839 ms avg

Latency correlation analysis on `product-catalog` (GetProduct transaction) identified commit `c1d42f47fa01f6b0696660c13fd8f1e4b762be71` as the root cause.

## The Bug

The commit introduced a `get_recommendations_ids()` caching function with a critical bug in the cache-miss path:

```python
for x in cat_response.products:
    ids_to_add.extend(cached_ids)   # ← BUG: extends with entire cached_ids on every product!
    ids_to_add.append(x.id)
    if len(ids_to_add) + len(cached_ids) < MAX_CACHED_IDS:
        cached_ids = cached_ids + ids_to_add  # ← BUG: O(n²) growth
```

On every cache miss, for each product in the catalog, `ids_to_add` is extended with the **entire `cached_ids` list**, causing **O(n²) memory growth**. With `MAX_CACHED_IDS = 2,000,000`, this quickly results in massive list operations that block the recommendation service and cascade latency to all upstream services.

## Fix

Reverts to the original, correct implementation that directly calls `ListProducts` without the broken caching layer:

```python
cat_response = product_catalog_stub.ListProducts(demo_pb2.Empty())
product_ids = [x.id for x in cat_response.products]
```

## Impact

- Fixes latency spike on `GET /api/recommendations` (754 ms → expected ~20 ms)
- Resolves cascading latency across `recommendation`, `frontend`, and `frontend-proxy`
- Eliminates unbounded memory growth in the recommendation service pod