### PR TITLE
fix: revert buggy recommendation caching logic causing latency spike

### DIFF
--- a/src/recommendation/recommendation_server.py
+++ b/src/recommendation/recommendation_server.py
@@ -37,10 +37,6 @@ from metrics import (
 )
 
 
-cached_ids = []
-cached_ids_to_retrieve_recommendations_for = []
-MAX_CACHED_IDS = 2000000
-
 first_run = True
 
 class RecommendationService(demo_pb2_grpc.RecommendationServiceServicer):
@@ -67,31 +63,6 @@ class RecommendationService(demo_pb2_grpc.RecommendationServiceServicer):
         return health_pb2.HealthCheckResponse(
             status=health_pb2.HealthCheckResponse.UNIMPLEMENTED)
 
-def get_recommendations_ids(request_product_ids):
-    global cached_ids
-
-    with tracer.start_as_current_span("get_recommendations_ids") as span:
-        can_retrieve_from_cache = True
-        for p_id in request_product_ids:
-            if p_id not in cached_ids_to_retrieve_recommendations_for:
-                can_retrieve_from_cache = False
-
-        if not can_retrieve_from_cache:
-            logger.info("get_recommendations_ids: cache miss")
-            span.set_attribute("app.cache_hit", False)
-            cat_response = product_catalog_stub.ListProducts(demo_pb2.Empty())
-            ids_to_add = []
-            for x in cat_response.products:
-                ids_to_add.extend(cached_ids)
-                ids_to_add.append(x.id)
-                if len(ids_to_add) + len(cached_ids) < MAX_CACHED_IDS:
-                    cached_ids= cached_ids + ids_to_add
-            return cached_ids
-        else:
-            logger.info("get_recommendations_ids: cache hit")
-            span.set_attribute("app.cache_hit", True)
-            return cached_ids
-
 def get_product_list(request_product_ids):
     global first_run
     with tracer.start_as_current_span("get_product_list") as span:
@@ -101,7 +72,8 @@ def get_product_list(request_product_ids):
         request_product_ids_str = ''.join(request_product_ids)
         request_product_ids = request_product_ids_str.split(',')
 
-        product_ids = get_recommendations_ids(request_product_ids)
+        cat_response = product_catalog_stub.ListProducts(demo_pb2.Empty())
+        product_ids = [x.id for x in cat_response.products]
 
         span.set_attribute("app.products.count", len(product_ids))
 


### PR DESCRIPTION
## Problem

An active alert was triggered: **Avg. latency for `GET /api/recommendations` on `frontend-proxy` reached 435 ms** (threshold: 200 ms).

### Root Cause Analysis

Automated investigation traced the latency spike through the service topology:

**Call chain:** `load-generator` → [frontend-proxy](/app/apm/services/frontend-proxy) → [frontend](/app/apm/services/frontend) → [recommendation](/app/apm/services/recommendation) → [product-catalog](/app/apm/services/product-catalog)

**Change point detected at:** `2026-03-23T10:08:00Z`
- `frontend-proxy` latency spiked to **~647 ms** (from ~42 ms baseline)
- `recommendation` latency spiked to **~299 ms** (from ~5 ms baseline)
- `product-catalog` latency spiked to **~4 ms** (from ~1 ms baseline)

**Correlation analysis** identified `git.sha: 72f15750cce77d4414888363ed52087b0b0ee4b4` as the root cause, deployed on pod `recommendation-757f645fb6-tkn9d` (started `2026-03-23T10:06:55Z`).

### Bug in Commit `72f1575`

The introduced `get_recommendations_ids()` function contains a critical memory growth bug:

```python
for x in cat_response.products:
    ids_to_add.extend(cached_ids)   # ← BUG: appends entire cache for EACH product
    ids_to_add.append(x.id)
    if len(ids_to_add) + len(cached_ids) < MAX_CACHED_IDS:
        cached_ids = cached_ids + ids_to_add
```

On every cache miss, `ids_to_add` is extended with the full `cached_ids` list **for each product** in the catalog. This causes **exponential memory growth** up to `MAX_CACHED_IDS = 2,000,000` entries, making every subsequent call increasingly slow.

## Fix

Reverts to the original, correct implementation that directly calls `product_catalog_stub.ListProducts()` and extracts product IDs without any caching.

## Impact
- Resolves latency spike on `recommendation` service
- Restores `frontend-proxy` `GET /api/recommendations` latency to baseline (~42 ms)
